### PR TITLE
Update to use Laravel 5.5+ assertions

### DIFF
--- a/LoginTest.php
+++ b/LoginTest.php
@@ -40,7 +40,7 @@ class LoginTest extends TestCase
 
         $response->assertStatus(302);
 
-        $this->seeIsAuthenticatedAs($user);
+        $this->assertAuthenticatedAs($user);
     }
 
     /**
@@ -59,7 +59,7 @@ class LoginTest extends TestCase
 
         $response->assertSessionHasErrors();
 
-        $this->dontSeeIsAuthenticated();
+        $this->assertGuest();
     }
 
     /**
@@ -75,6 +75,6 @@ class LoginTest extends TestCase
 
         $response->assertStatus(302);
 
-        $this->dontSeeIsAuthenticated();
+        $this->assertGuest();
     }
 }

--- a/RegisterTest.php
+++ b/RegisterTest.php
@@ -42,7 +42,7 @@ class RegisterTest extends TestCase
 
         $response->assertStatus(302);
 
-        $this->seeIsAuthenticated();
+        $this->assertAuthenticated();
     }
 
     /**
@@ -63,6 +63,6 @@ class RegisterTest extends TestCase
 
         $response->assertSessionHasErrors();
 
-        $this->dontSeeIsAuthenticated();
+        $this->assertGuest();
     }
 }


### PR DESCRIPTION
In Laravel 5.5 the authentication test methods were update from `seeXXX` to `assertXXX`:

* `seeIsAuthenticatedAs` => `assertAuthenticatedAs`
* `seeIsAuthenticated` => `assertAuthenticated`
* `dontSeeIsAuthenticated` => `assertGuest`