### PR TITLE
Change 'secret' to 'password'

### DIFF
--- a/LoginTest.php
+++ b/LoginTest.php
@@ -35,7 +35,7 @@ class LoginTest extends TestCase
 
         $response = $this->post('/login', [
             'email' => $user->email,
-            'password' => 'secret'
+            'password' => 'password'
         ]);
 
         $response->assertStatus(302);

--- a/RegisterTest.php
+++ b/RegisterTest.php
@@ -36,8 +36,8 @@ class RegisterTest extends TestCase
         $response = $this->post('register', [
             'name' => $user->name,
             'email' => $user->email,
-            'password' => 'secret',
-            'password_confirmation' => 'secret'
+            'password' => 'password',
+            'password_confirmation' => 'password'
         ]);
 
         $response->assertStatus(302);
@@ -57,7 +57,7 @@ class RegisterTest extends TestCase
         $response = $this->post('register', [
             'name' => $user->name,
             'email' => $user->email,
-            'password' => 'secret',
+            'password' => 'password',
             'password_confirmation' => 'invalid'
         ]);
 


### PR DESCRIPTION
The default user factory value was changed from "secret" to "password" 
Here is the commit where it changed https://github.com/laravel/laravel/commit/9db658d6d1dde21dfe243bbed9450f242858ec8c#diff-d5f47c0c4df86dac0372f74022418ac6

This made it a little confusing when running the tests and not seeing why a user attempt failed